### PR TITLE
Fix illegal timestamp default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Helfi - Audit log",
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3"

--- a/helfi_audit_log.install
+++ b/helfi_audit_log.install
@@ -23,7 +23,7 @@ function helfi_audit_log_schema() {
         'mysql_type' => 'timestamp',
         'not null' => TRUE,
         'description' => 'Timestamp when the record was created.',
-        'default' => '2203-06-28 12:00:00',
+        'default' => '2023-06-28 12:00:00',
       ],
       'message' => [
         'type' => 'text',


### PR DESCRIPTION
Fix illegal timestamp default, which will throw errors on clean drupal installation.

https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/604